### PR TITLE
Add "Incorrect key" error

### DIFF
--- a/lib/backend_pcsc.c
+++ b/lib/backend_pcsc.c
@@ -264,7 +264,7 @@ backend_authenticate (ykneomgr_dev * dev, const uint8_t * key)
 
   if (memcmp (tmp, recv + 20, DES_BLOCK_SIZE) != 0)
     {
-      return YKNEOMGR_BACKEND_ERROR;
+      return YKNEOMGR_INCORRECT_KEY;
     }
 
   buf[0] = recv[12];

--- a/lib/error.c
+++ b/lib/error.c
@@ -31,7 +31,8 @@ static const err_t errors[] = {
   ERR (YKNEOMGR_MEMORY_ERROR, "Memory error (e.g., out of memory)"),
   ERR (YKNEOMGR_NO_DEVICE, "No device found"),
   ERR (YKNEOMGR_TOO_MANY_DEVICES, "Too many devices found"),
-  ERR (YKNEOMGR_BACKEND_ERROR, "Backend error")
+  ERR (YKNEOMGR_BACKEND_ERROR, "Backend error"),
+  ERR (YKNEOMGR_INCORRECT_KEY, "Incorrect key")
 };
 
 /**

--- a/lib/ykneomgr/ykneomgr-types.h
+++ b/lib/ykneomgr/ykneomgr-types.h
@@ -25,6 +25,7 @@
  * @YKNEOMGR_NO_DEVICE: No device found.
  * @YKNEOMGR_TOO_MANY_DEVICES: Too many devices found.
  * @YKNEOMGR_BACKEND_ERROR: Input/Output error.
+ * @YKNEOMGR_INCORRECT_KEY: Key error.
  *
  * Error codes.
  */
@@ -35,6 +36,7 @@ typedef enum
   YKNEOMGR_NO_DEVICE = -2,
   YKNEOMGR_TOO_MANY_DEVICES = -3,
   YKNEOMGR_BACKEND_ERROR = -4,
+  YKNEOMGR_INCORRECT_KEY = -5,
 } ykneomgr_rc;
 
 /**


### PR DESCRIPTION
This will show "Incorrect key" rather than "Backend error"
if the device has a different transport key.
